### PR TITLE
Fix ETIMEDOUT and EAI_AGAIN polling errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-1-0ea05deb
+Your prepared working directory: /tmp/gh-issue-solver-1760718813771
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-1-0ea05deb
-Your prepared working directory: /tmp/gh-issue-solver-1760718813771
-
-Proceed.

--- a/index.js
+++ b/index.js
@@ -42,7 +42,24 @@ function getVerdict(facts) {
 
 
 function start(token) {
-  const bot = new TelegramBot(token, {polling: true});
+  const bot = new TelegramBot(token, {
+    polling: true,
+    request: {
+      agentOptions: {
+        keepAlive: true,
+        family: 4
+      },
+      url: "https://api.telegram.org"
+    }
+  });
+
+  // Handle polling errors to prevent crashes
+  bot.on('polling_error', (error) => {
+    console.error('error: [polling_error]', JSON.stringify({
+      code: error.code,
+      message: error.message
+    }));
+  });
 
   bot.onText(/\/(re)?start/, (msg) => {
     const chatId = msg.chat.id;


### PR DESCRIPTION
## Summary
Fixes #1 

This PR resolves the `EFATAL: Error: read ETIMEDOUT` and `EFATAL: Error: getaddrinfo EAI_AGAIN api.telegram.org` polling errors that occur after the bot runs for extended periods.

## Changes Made
- Added request configuration with `agentOptions` to force IPv4 connections (`family: 4`)
- Enabled `keepAlive` for persistent connections to reduce connection overhead
- Explicitly set the Telegram API URL
- Added `polling_error` event handler to log errors without crashing the bot

## Technical Details
The errors were caused by network connectivity issues when polling the Telegram API. The fix addresses this by:

1. **Forcing IPv4**: Setting `family: 4` avoids DNS resolution issues (EAI_AGAIN errors)
2. **Keep-alive connections**: Maintains persistent connections to prevent timeout errors
3. **Explicit API URL**: Ensures consistent connection endpoint
4. **Error handling**: Logs polling errors gracefully instead of letting them crash the bot

## Testing
- Syntax validation passed
- Error handling properly logs errors in the expected format

🤖 Generated with [Claude Code](https://claude.com/claude-code)