### PR TITLE
Fix ETELEGRAM: 404 Not Found error by trimming token

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-2-ae1607ab
+Your prepared working directory: /tmp/gh-issue-solver-1760719179845
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-2-ae1607ab
-Your prepared working directory: /tmp/gh-issue-solver-1760719179845
-
-Proceed.

--- a/index.js
+++ b/index.js
@@ -121,6 +121,6 @@ fs.readFile('token', 'utf8', (err, data) => {
     console.log("Make sure token file exists and contains Telegram Bot token");
     return;
   }
-  start(data);
+  start(data.trim());
 });
 


### PR DESCRIPTION
## 🐛 Bug Fix

Fixes #2 

## 📝 Problem

The bot was throwing `ETELEGRAM: 404 Not Found` error when starting up. This error occurs when the Telegram Bot API receives an invalid or malformed token.

## 🔍 Root Cause

The issue was in `index.js:124` where the token was read from the `token` file using `fs.readFile()`. The raw data from the file included trailing whitespace (newlines, spaces, etc.), which made the token invalid when passed to the Telegram Bot API.

```javascript
// Before (line 124)
start(data);

// After (line 124)  
start(data.trim());
```

## ✅ Solution

Added `.trim()` method to remove leading and trailing whitespace from the token before initializing the bot. This ensures the token is in the correct format expected by the Telegram API.

## 🧪 Testing

The fix addresses the root cause identified through:
- Analysis of the error message (404 indicates invalid token)
- Research on common causes of ETELEGRAM 404 errors in node-telegram-bot-api
- Review of the token reading logic in the codebase

## 📚 References

Common causes of this error include:
- Extra whitespace in token files
- Invalid token format
- Revoked or expired tokens

This fix handles the most common case where users save their token to a file with a trailing newline character.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)